### PR TITLE
fix version regex

### DIFF
--- a/.arcconfig
+++ b/.arcconfig
@@ -1,4 +1,7 @@
 {
   "phabricator.uri": "https://devcentral.nasqueron.org/",
-  "repository.callsign": "SCL"
+  "repository.callsign": "SCL",
+  "load": [
+    "shellcheck-linter"
+  ]
 }

--- a/.arcunit
+++ b/.arcunit
@@ -1,0 +1,8 @@
+{
+  "engines": {
+    "phutil": {
+      "type": "phutil",
+      "include": "(\\.php$)"
+    }
+  }
+}

--- a/__phutil_library_map__.php
+++ b/__phutil_library_map__.php
@@ -10,9 +10,11 @@ phutil_register_library_map(array(
   '__library_version__' => 2,
   'class' => array(
     'ArcanistShellCheckLinter' => 'lint/linter/ArcanistShellCheckLinter.php',
+    'ArcanistShellCheckLinterTestCase' => 'lint/linter/__tests__/ArcanistShellCheckLinterTestCase.php',
   ),
   'function' => array(),
   'xmap' => array(
     'ArcanistShellCheckLinter' => 'ArcanistExternalLinter',
+    'ArcanistShellCheckLinterTestCase' => 'PhutilTestCase',
   ),
 ));

--- a/lint/linter/ArcanistShellCheckLinter.php
+++ b/lint/linter/ArcanistShellCheckLinter.php
@@ -105,7 +105,7 @@ final class ArcanistShellCheckLinter extends ArcanistExternalLinter {
       '%C --version', $this->getExecutableCommand());
 
     $matches = null;
-    if (preg_match('/^version: (\d(?:\.\d){2})$/', $stdout, $matches)) {
+    if (preg_match('/version: (\d(?:\.\d){2})/', $stdout, $matches)) {
       return $matches[1];
     }
 

--- a/lint/linter/__tests__/ArcanistShellCheckLinterTestCase.php
+++ b/lint/linter/__tests__/ArcanistShellCheckLinterTestCase.php
@@ -1,0 +1,13 @@
+<?php
+
+final class ArcanistShellCheckLinterTestCase extends PhutilTestCase {
+
+  public function testGetVersion() {
+    $linter = new ArcanistShellCheckLinter();
+    $actualVersion = $linter->getVersion();
+
+    $this->assertFalse($actualVersion === null, "The version can't be extracted from the binary output.");
+    $this->assertTrue(strpos($actualVersion, '.') > -1, "The version doesn't match expected format: does not contain a dot.");
+  }
+
+}


### PR DESCRIPTION
In the current state, the `getVersion()` function always returns `null` so version-pinning in arcanist doesn't work. This is because the version output is multiline:
```
➜  ~ shellcheck --version
ShellCheck - shell script analysis tool
version: 0.6.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net
➜  ~
```

The current regex requires matching beginning and end of the output. By removing those, allowing the version output to be in the middle of other output, I can get version pinning to work:
```
➜  ~ arc lint --everything
Exception
Linter ArcanistShellCheckLinter requires shellcheck version 0.2.0. You have version 0.6.0.
(Run with `--trace` for a full exception trace.)
➜  ~
```