### PR TITLE
change description URL to HTTPS

### DIFF
--- a/lint/linter/ArcanistShellCheckLinter.php
+++ b/lint/linter/ArcanistShellCheckLinter.php
@@ -10,7 +10,7 @@ final class ArcanistShellCheckLinter extends ArcanistExternalLinter {
   }
 
   public function getInfoURI() {
-    return 'http://www.shellcheck.net/';
+    return 'https://www.shellcheck.net/';
   }
 
   public function getInfoDescription() {


### PR DESCRIPTION
The plaintext HTTP URL just redirects to HTTPS

```
➜  ~ curl -svo /dev/null http://www.shellcheck.net/
*   Trying 23.251.146.157...
* TCP_NODELAY set
* Connected to www.shellcheck.net (23.251.146.157) port 80 (#0)
> GET / HTTP/1.1
> Host: www.shellcheck.net
> User-Agent: curl/7.64.1-DEV
> Accept: */*
>
< HTTP/1.1 302 Found
< Date: Tue, 11 Jun 2019 00:22:13 GMT
< Server: Apache/2.4.38 (Debian)
< Location: https://www.shellcheck.net/
< Content-Length: 295
< Content-Type: text/html; charset=iso-8859-1
<
{ [295 bytes data]
* Connection #0 to host www.shellcheck.net left intact
* Closing connection 0
```